### PR TITLE
Get rid of statcache option.

### DIFF
--- a/HHVMDaemon.php
+++ b/HHVMDaemon.php
@@ -93,7 +93,6 @@ final class HHVMDaemon extends PHPEngine {
       '-v', 'Server.Type=fastcgi',
       '-v', 'Eval.Jit=1',
       '-v', 'AdminServer.Port='.PerfSettings::FastCGIAdminPort(),
-      '-v', 'Server.StatCache=1',
       '-c', __DIR__.'/php.ini',
     };
     if (count($this->options->hhvmExtraArguments) > 0) {


### PR DESCRIPTION
It was originally there because it improved performance under /dev/shm.
No longer required (we're using /tmp). Improves Drupal7 performance,
does not hurt Wordpress performance.
