### PR TITLE
allow user to specify concurrency

### DIFF
--- a/core/PerfOptions.php
+++ b/core/PerfOptions.php
@@ -60,6 +60,7 @@ final class PerfOptions {
   public string $tempDir;
 
   public bool $notBenchmarking = false;
+  public int  $benchmarkConcurrency;
 
   private array $args;
   private Vector<string> $notBenchmarkingArgs = Vector { };
@@ -76,6 +77,7 @@ final class PerfOptions {
       'nginx:',
 
       'i-am-not-benchmarking',
+      'concurrency:',
 
       'hhvm-extra-arguments:',
 
@@ -128,6 +130,7 @@ final class PerfOptions {
     $this->traceSubProcess = array_key_exists('trace', $o);
 
     $this->notBenchmarking = array_key_exists('i-am-not-benchmarking', $o);
+    $this->benchmarkConcurrency = hphp_array_idx($o, 'concurrency', 60);
 
     // If any arguments below here are given, then the "standard
     // semantics" have changed, and any results are potentially not

--- a/core/PerfSettings.php
+++ b/core/PerfSettings.php
@@ -28,10 +28,6 @@ final class PerfSettings {
     return '1M'; // 1 minute
   }
 
-  public static function BenchmarkConcurrency(): int {
-    return 60;
-  }
-
   ///// Server Settings /////
 
   public static function HttpPort(): int {

--- a/core/Siege.php
+++ b/core/Siege.php
@@ -87,7 +87,7 @@ final class Siege extends Process {
         };
       case RequestModes::BENCHMARK:
         $bench = Vector {
-          '-c', (string) PerfSettings::BenchmarkConcurrency(),
+          '-c', (string) $this->options->benchmarkConcurrency,
           '-f', $urls_file,
           '--benchmark',
           '--log='.$this->logfile,


### PR DESCRIPTION
I'm sure for a lot of benchmarks, 60 won't make a ton of sense.
For example there are much bigger gains with Magento when I use a
concurrency of 200.

We still fall back to 60.
