### PR TITLE
Export env var OSS_PERF_TARGET holding the target's name.

### DIFF
--- a/base/HHVMDaemon.php
+++ b/base/HHVMDaemon.php
@@ -141,6 +141,12 @@ final class HHVMDaemon extends PHPEngine {
     }
   }
 
+  protected function getEnvironmentVariables(): Map<string, string> {
+    return Map {
+      'OSS_PERF_TARGET' => (string) $this->target,
+    };
+  }
+
   public function __toString(): string {
     return (string) $this->options->hhvm;
   }

--- a/base/PHP5Daemon.php
+++ b/base/PHP5Daemon.php
@@ -100,6 +100,7 @@ final class PHP5Daemon extends PHPEngine {
 
   protected function getEnvironmentVariables(): Map<string, string> {
     return Map {
+      'OSS_PERF_TARGET' => (string) $this->target,
       'PHP_FCGI_CHILDREN' => (string) $this->options->phpFCGIChildren,
       'PHP_FCGI_MAX_REQUESTS' => '0',
     };


### PR DESCRIPTION
This is useful so that the instrumented process can
change its behavior, such as changing log files or
invocation naming.