### PR TITLE
Add new profling options for Facebook/hhvm

### DIFF
--- a/base/NginxDaemon.php
+++ b/base/NginxDaemon.php
@@ -116,7 +116,7 @@ final class NginxDaemon extends Process {
       // Watch out!  The -g arguments to nginx do not accumulate.
       // The last one wins, and is the only one evaluated by nginx.
       //
-      '-g', 'daemon off; '.'pid '.$this->getPidFilePath().'; ',
+      '-g', 'daemon off;',
     };
   }
 
@@ -148,6 +148,7 @@ final class NginxDaemon extends Process {
       '__NGINX_FASTCGI_READ_TIMEOUT__' =>
         (int)$this->options->maxdelayNginxFastCGI,
       '__FRAMEWORK_ROOT__' => $this->target->getSourceRoot(),
+      '__NGINX_PID_FILE__' => $this->getPidFilePath(),
     };
 
     $config = file_get_contents(

--- a/base/PHPEngine.php
+++ b/base/PHPEngine.php
@@ -11,4 +11,5 @@
 
 abstract class PHPEngine extends Process {
   public abstract function __toString(): string;
+  public function writeStats(): void {}
 }

--- a/base/PerfSettings.php
+++ b/base/PerfSettings.php
@@ -16,7 +16,7 @@ final class PerfSettings {
   // Per concurrent thread - so, total number of requests made during warmup
   // is WarmupRequests * WarmupConcurrency
   public static function WarmupRequests(): int {
-    return 50;
+    return 300;
   }
 
   public static function WarmupConcurrency(): int {

--- a/base/RequestMode.php
+++ b/base/RequestMode.php
@@ -12,6 +12,11 @@
 newtype RequestMode = string;
 
 final class RequestModes {
+  // Single threaded warmup requests to ensure near optimal TC layout
   const RequestMode WARMUP = 'warmup';
+  // Complete run of parallel requests is for a handful of frameworks that
+  // continue to substantially JIT even after a high volume of single threaded
+  // requests (mostly in conjunction with broken pseudomain JITing).
+  const RequestMode WARMUP_MULTI = 'warmup-multi';
   const RequestMode BENCHMARK = 'benchmark';
 }

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -91,12 +91,12 @@ final class Siege extends Process {
     if (!$this->options->noTimeLimit) {
       $arguments = Vector {
         // See Siege::getExecutablePath()  - these arguments get passed to
-        // 'timeout'
-        '-k', '5m',
+        // timeout
+        '--signal=9',
         '5m',
         parent::getExecutablePath(),
       };
-    };
+    }
     $siege_rc = $this->target->getSiegeRCPath();
     if ($siege_rc !== null) {
       $arguments->addAll(Vector {
@@ -109,6 +109,15 @@ final class Siege extends Process {
         $arguments->addAll(Vector {
           '-c', (string) PerfSettings::WarmupConcurrency(),
           '-r', (string) PerfSettings::WarmupRequests(),
+          '-f', $urls_file,
+          '--benchmark',
+          '--log=/dev/null',
+        });
+        return $arguments;
+      case RequestModes::WARMUP_MULTI:
+        $arguments->addAll(Vector {
+          '-c', (string) PerfSettings::BenchmarkConcurrency(),
+          '-t', '1M',
           '-f', $urls_file,
           '--benchmark',
           '--log=/dev/null',

--- a/base/Utils.php
+++ b/base/Utils.php
@@ -34,4 +34,7 @@ final class Utils {
   public static function EscapeCommand(Vector<string> $command): string {
     return implode(' ', $command->map($x ==> escapeshellarg($x)));
   }
+  public static function RunCommand(Vector<string> $args): string {
+    return shell_exec(self::EscapeCommand($args));
+  }
 }

--- a/conf/nginx/nginx.conf.in
+++ b/conf/nginx/nginx.conf.in
@@ -4,6 +4,7 @@
 
 worker_processes  5;
 error_log __NGINX_TEMP_DIR__/nginx-error.log;
+pid __NGINX_PID_FILE__;
 
 events {
   worker_connections  1024;

--- a/targets/wordpress/WordpressTarget.php
+++ b/targets/wordpress/WordpressTarget.php
@@ -78,11 +78,6 @@ final class WordpressTarget extends PerfTarget {
   // Contact rpc.pingomatic.com, upgrade to latest .z release, other periodic
   // tasks
   public function unfreeze(PerfOptions $options): void {
-    // Need internet access or wordpress will keep on retrying this stuff
-    if (!file_get_contents('http://www.example.com')) {
-      throw new Exception(
-        'Wordpress requires internet access to http://www.example.com');
-    }
     // Does basic bookkeeping...
     $this->unfreezeRequest($options);
     // Does more involved stuff like upgrading wordpress...


### PR DESCRIPTION
Summary: This is commit adds a hand full of convenience options for:
- Enabling/disabling the FileCache and RepoAuthoritative mode during profiling
- Generating TCDumps (optionally of the top functions/translations)
- Profiling bytecodes (as opposed to PHP functions)
- Keeping the server on online after profiling is complete
- Running repo-mode with AllVolatile enabled (hoisting is technically broken...sigh)
- Adjusting the PCRE caching scheme, and cache size
- Dumping the contents of the PCRE cache
- Interpreting all pseudomains (guard relaxation is broken for pseudomains...sigh)
- fbcode option to use an fbcode build of hhvm/tc-print (the latter being for TCDumps)

The following changes were also made:
- Run 300 serial warmup requests
- Run one round of parallel requests before benchmarking
- Write the pid file path to nginx.conf (useful for testing)
- Remove the check for connectivity in wordpress (was unnecessary, and proxies suck)
- Remove the -k option for timeout (not supported on devservers)

The following is still broken on devservers:
- Cannot create databases with MyISAM tables (not sure of the best fix but we do need to fix this)

The following features would be useful in a followup PR:
- Option to run linux perf tool
- Option to run rollup tool (integrated with fbcode option)
- Option to dump repo
- Option to dump file-cache

The additional warmup time was added after inspecting the tc-filling behavior and discovering that tc size was still dramatically increasing after 50 warmup requests. The additional serial warmup requests ensure near optimal tc layout, while the extra complete run of parallel requests is for a handful of frameworks that continue to substantially JIT even after a high volume of single threaded requests (mostly in conjunction with broken pseudomain JITing). While inconvenient the added warmup should ensure better consistency (this was certainly observed in testing). It's also particularly important in repo-auth mode where hot functions are JITed into Ahot after appropriate profiling which may further delay warmup. 

Test Plan: Tested all new options, ran hh_client