### PR TITLE
Add setUpTest and tearDownTest to run a bash script at the right time.

### DIFF
--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -21,6 +21,13 @@ final class PerfOptions {
   public ?string $php5;
   public ?string $hhvm;
 
+  //
+  // setUpTest and tearDownTest are called before and after each
+  // individual invocation of the $php5 or $hhvm
+  //
+  public ?string $setUpTest;
+  public ?string $tearDownTest;
+
   public array $hhvmExtraArguments;
   public array $phpExtraArguments;
 
@@ -124,6 +131,9 @@ final class PerfOptions {
       'dump-pcre-cache',
       'profBC',
 
+      'setUpTest:',
+      'tearDownTest:',
+
       'i-am-not-benchmarking',
 
       'hhvm-extra-arguments:',
@@ -176,6 +186,9 @@ final class PerfOptions {
 
     $this->php5 = hphp_array_idx($o, 'php5', null);
     $this->hhvm = hphp_array_idx($o, 'hhvm', null);
+
+    $this->setUpTest = hphp_array_idx($o, 'setUpTest', null);
+    $this->tearDownTest = hphp_array_idx($o, 'tearDownTest', null);
 
     $this->siege = hphp_array_idx($o, 'siege', 'siege');
     $this->nginx = hphp_array_idx($o, 'nginx', 'nginx');

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -58,6 +58,18 @@ final class PerfRunner {
 
     $target->install();
 
+    if ($options->setUpTest != null) {
+      $command = "OSS_PERF_PHASE=" . "setUp"
+         . " " . "OSS_PERF_TARGET=" . (string) $target
+         . " " . $options->setUpTest
+         ;
+      self::PrintProgress('Starting setUpTest ' . $command);
+      shell_exec($command);
+      self::PrintProgress('Finished setUpTest ' . $command);
+    } else {
+      self::PrintProgress('There is no setUpTest');
+    }
+
     self::PrintProgress('Starting Nginx');
     $nginx = new NginxDaemon($options, $target);
     $nginx->start();
@@ -148,6 +160,18 @@ final class PerfRunner {
       fread(STDIN, 1);
     }
     $php_engine->stop();
+
+    if ($options->tearDownTest != null) {
+      $command = "OSS_PERF_PHASE=" . "tearDown"
+         . " " . "OSS_PERF_TARGET=" . (string) $target
+         . " " . $options->tearDownTest
+         ;
+      self::PrintProgress('Starting tearDownTest ' . $command);
+      shell_exec($command);
+      self::PrintProgress('Finished tearDownTest ' . $command);
+    } else {
+      self::PrintProgress('There is no tearDownTest');
+    }
 
     return $combined_stats;
   }

--- a/batch-run.php
+++ b/batch-run.php
@@ -19,6 +19,8 @@ type BatchRuntime = shape(
   'type' => BatchRuntimeType,
   'bin' => string,
   'args' => Vector<string>,
+  'setUpTest' => string,
+  'tearDownTest' => string,
 );
 
 type BatchTarget = shape(
@@ -31,6 +33,10 @@ function batch_get_runtime(string $name, array $data): BatchRuntime {
     'name' => $name,
     'type' => $data['type'],
     'bin' => $data['bin'],
+    'setUpTest' => array_key_exists('setUpTest', $data)
+      ? $data['setUpTest'] : null,
+    'tearDownTest' => array_key_exists('tearDownTest', $data)
+      ? $data['tearDownTest'] : null,
     'args' => array_key_exists('args', $data)
       ? new Vector($data['args'])
       : Vector { },
@@ -135,6 +141,10 @@ function batch_get_single_run(
       $options->php5 = $runtime['bin'];
       break;
   }
+
+  $options->setUpTest = $runtime['setUpTest'];
+  $options->tearDownTest = $runtime['tearDownTest'];
+
   $options->validate();
 
   return $options;


### PR DESCRIPTION
The bash script is run with environment variable OSS_PERF_PHASE set to
either "setUpTest" or "tearDownTest"; the variable OSS_PERF_TARGET is
set to the target at hand.