### PR TITLE
Rebuild the nginx.conf file everytime it is asked for.

### DIFF
--- a/base/NginxDaemon.php
+++ b/base/NginxDaemon.php
@@ -132,9 +132,6 @@ final class NginxDaemon extends Process {
 
   protected function getGeneratedConfigFile(): string {
     $path = $this->options->tempDir.'/nginx.conf';
-    if (file_exists($path)) {
-      return $path;
-    }
 
     $substitutions = Map {
       '__FASTCGI_PORT__' => PerfSettings::FastCGIPort(),
@@ -149,6 +146,7 @@ final class NginxDaemon extends Process {
         (int)$this->options->maxdelayNginxFastCGI,
       '__FRAMEWORK_ROOT__' => $this->target->getSourceRoot(),
       '__NGINX_PID_FILE__' => $this->getPidFilePath(),
+      '__DATE__' => date(DATE_W3C),
     };
 
     $config = file_get_contents(

--- a/conf/nginx/nginx.conf.in
+++ b/conf/nginx/nginx.conf.in
@@ -2,6 +2,12 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
+#
+# DO NOT EDIT: This file is automatically made by expanding
+# conf/nginx/nginx.conf.in
+#
+# This file was created on: __DATE__
+
 worker_processes  5;
 error_log __NGINX_TEMP_DIR__/nginx-error.log;
 pid __NGINX_PID_FILE__;


### PR DESCRIPTION
In this way the correct document root is used on each iteration
of the batch run.

This appears to fix https://github.com/hhvm/oss-performance/issues/31

There may yet be other occurrences of this anti-pattern