### PR TITLE
Added paramter --wait-after-warmup

### DIFF
--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -48,6 +48,8 @@ final class PerfOptions {
   // Pause once benchmarking is complete to allow for manual inspection of the
   // HHVM or PHP process.
   public bool $waitAtEnd = false;
+  // Pause after the warmup is completed to get relevant data when profiling
+  public bool $waitAfterWarmup = false;
 
   //
   // HHVM specific options to enable RepoAuthoritative mode and the static
@@ -116,6 +118,7 @@ final class PerfOptions {
       'siege:',
       'nginx:',
       'wait-at-end',
+      'wait-after-warmup',
       'no-proxygen',
       'no-repo-auth',
       'no-file-cache',
@@ -216,6 +219,7 @@ final class PerfOptions {
 
     $this->skipSanityCheck = $this->getBool('skip-sanity-check');
     $this->skipWarmUp = $this->getBool('skip-warmup');
+    $this->waitAfterWarmup = $this->getBool('wait-after-warmup');
     $this->skipVersionChecks = $this->getBool('skip-version-checks');
     $this->skipDatabaseInstall = $this->getBool('skip-database-install');
     $this->noTimeLimit = $this->getBool('no-time-limit');

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -134,6 +134,11 @@ final class PerfRunner {
     self::PrintProgress('Clearing nginx access.log');
     $nginx->clearAccessLog();
 
+    if ($options->waitAfterWarmup) {
+      self::PrintProgress('Finished warmup. Press Enter to continue the benchmark');
+      fread(STDIN, 1);
+    }
+
     self::PrintProgress('Starting Siege for benchmark');
     $siege = new Siege($options, $target, RequestModes::BENCHMARK);
     $siege->start();


### PR DESCRIPTION
Summary:
When running with the parameter wait after warmup, perf
waits for user input before continuing the benchmark. This
feature is useful when you want to profile HHVM.
Using this option, you have more control over the hhvm that is
being benhmark. You can get more accurate profile information
as you can start the profile only after the warmup is done.