### PR TITLE
Bump types_hash variables

### DIFF
--- a/conf/nginx/nginx.conf.in
+++ b/conf/nginx/nginx.conf.in
@@ -21,6 +21,9 @@ http {
   default_type  application/octet-stream;
 
   log_format main '$status $body_bytes_sent $request_time "$request"';
+  
+  types_hash_max_size 4096;
+  types_hash_bucket_size 64;
 
   sendfile        on;
   #tcp_nopush     on;


### PR DESCRIPTION
```
nginx: [emerg] could not build the types_hash, you should increase either types_hash_max_size: 1024 or types_hash_bucket_size: 32
```

Seen on Ubuntu 12.04