### PR TITLE
Parameters for running scripts/commands at specific times.

### DIFF
--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -104,6 +104,10 @@ final class PerfOptions {
   public string $tempDir;
   public ?string $srcDir;
 
+  public ?string $scriptBeforeWarmup;
+  public ?string $scriptAfterWarmup;
+  public ?string $scriptAfterBenchmark;
+
   public bool $notBenchmarking = false;
 
   private array $args;
@@ -156,6 +160,9 @@ final class PerfOptions {
       'max-delay-admin-request:',
       'max-delay-nginx-keepalive:',
       'max-delay-nginx-fastcgi:',
+      'exec-before-warmup:',
+      'exec-after-warmup:',
+      'exec-after-benchmark:',
       'daemon-files', // daemon output goes to files in the temp directory
       'temp-dir:', // temp directory to use; if absent one in /tmp is made
       'src-dir:', // location for source to copy into tmp dir instead of ZIP
@@ -234,6 +241,10 @@ final class PerfOptions {
     $this->pcreExpire = $this->getNullableInt('pcre-cache-expire');
     $this->allVolatile = $this->getBool('all-volatile');
     $this->interpPseudomains = $this->getBool('interp-pseudomains');
+
+    $this->scriptBeforeWarmup = $this->getNullableString('exec-before-warmup');
+    $this->scriptAfterWarmup = $this->getNullableString('exec-after-warmup');
+    $this->scriptAfterBenchmark = $this->getNullableString('exec-after-benchmark');
 
     if ($this->getBool('tcprint')) {
       $tcprint = hphp_array_idx($o, 'tcprint', null);

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -99,6 +99,11 @@ final class PerfRunner {
       $target->sanityCheck();
     }
 
+    if ($options->scriptBeforeWarmup !== null) {
+      self::PrintProgress('Starting execution of command: '.$options->scriptBeforeWarmup);
+      exec($options->scriptBeforeWarmup);
+    }
+
     if (!$options->skipWarmUp) {
       self::PrintProgress('Starting Siege for single request warmup');
       $siege = new Siege($options, $target, RequestModes::WARMUP);
@@ -139,11 +144,21 @@ final class PerfRunner {
       fread(STDIN, 1);
     }
 
+    if ($options->scriptAfterWarmup !== null) {
+      self::PrintProgress('Starting execution of command: '.$options->scriptAfterWarmup);
+      exec($options->scriptAfterWarmup);
+    }
+
     self::PrintProgress('Starting Siege for benchmark');
     $siege = new Siege($options, $target, RequestModes::BENCHMARK);
     $siege->start();
     invariant($siege->isRunning(), 'Siege failed to start');
     $siege->wait();
+
+    if ($options->scriptAfterBenchmark !== null) {
+      self::PrintProgress('Starting execution of command: '.$options->scriptAfterBenchmark);
+      exec($options->scriptAfterBenchmark);
+    }
 
     self::PrintProgress('Collecting results');
 


### PR DESCRIPTION
Added three parameters for running scripts/commands before warmup, after warmup
and after benchmark.
Internally we use these parameters to profile HHVM using VTune/perf or to
regenerate the oss hot section ordering file.

Example for running VTune:
perf.php --wordpress  \
	 --i-am-not-benchmarking \
	 --exec-after-warmup="amplxe-cl \
		-collect advanced-hotspots  \
		--analyze-system \
		--d 60 > dmp_vtune.txt &" \
	 --hhvm=$HHVM_PATH