### PR TITLE
Remove suffix '5' from PHP options.

### DIFF
--- a/base/PHPDaemon.php
+++ b/base/PHPDaemon.php
@@ -9,18 +9,18 @@
  *
  */
 
-final class PHP5Daemon extends PHPEngine {
+final class PHPDaemon extends PHPEngine {
   private PerfTarget $target;
 
   public function __construct(private PerfOptions $options) {
     $this->target = $options->getTarget();
-    parent::__construct((string) $options->php5);
+    parent::__construct((string) $options->php);
 
     $output = [];
     $check_command = implode(
       ' ',
       (Vector {
-         $options->php5,
+         $options->php,
          '-q',
          '-c',
          OSS_PERFORMANCE_ROOT.'/conf',
@@ -36,7 +36,7 @@ final class PHP5Daemon extends PHPEngine {
     invariant($checks, 'Got invalid output from php-src_config_check.php');
     BuildChecker::Check(
       $options,
-      (string) $options->php5,
+      (string) $options->php,
       $checks,
       Set {'PHP_VERSION', 'PHP_VERSION_ID'},
     );
@@ -44,7 +44,7 @@ final class PHP5Daemon extends PHPEngine {
 
   public function start(): void {
     parent::startWorker(
-      $this->options->daemonOutputFileName('php5'),
+      $this->options->daemonOutputFileName('php'),
       $this->options->delayProcessLaunch,
       $this->options->traceSubProcess,
     );
@@ -114,6 +114,6 @@ final class PHP5Daemon extends PHPEngine {
   }
 
   public function __toString(): string {
-    return (string) $this->options->php5;
+    return (string) $this->options->php;
   }
 }

--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -14,16 +14,16 @@ final class PerfOptions {
   public bool $verbose;
 
   //
-  // Exactly one of php5 or hhvm must be set with the path
+  // Exactly one of php or hhvm must be set with the path
   // to the corresponding executable.  The one that is set
   // determines what kind of cgi server is run.
   //
-  public ?string $php5;
+  public ?string $php;
   public ?string $hhvm;
 
   //
   // setUpTest and tearDownTest are called before and after each
-  // individual invocation of the $php5 or $hhvm
+  // individual invocation of the $php or $hhvm
   //
   public ?string $setUpTest;
   public ?string $tearDownTest;
@@ -117,7 +117,7 @@ final class PerfOptions {
     $def = Vector {
       'help',
       'verbose',
-      'php5:',
+      'php:',
       'hhvm:',
       'siege:',
       'nginx:',
@@ -180,7 +180,7 @@ final class PerfOptions {
       fprintf(
         STDERR,
         "Usage: %s \\\n".
-        "  --<php5=/path/to/php-cgi|hhvm=/path/to/hhvm>\\\n".
+        "  --<php=/path/to/php-cgi|hhvm=/path/to/hhvm>\\\n".
         "  --<".
         implode('|', $targets).
         ">\n".
@@ -194,7 +194,7 @@ final class PerfOptions {
     ;
     $this->verbose = array_key_exists('verbose', $o);
 
-    $this->php5 = hphp_array_idx($o, 'php5', null);
+    $this->php = hphp_array_idx($o, 'php', null);
     $this->hhvm = hphp_array_idx($o, 'hhvm', null);
 
     $this->setUpTest = hphp_array_idx($o, 'setUpTest', null);
@@ -266,7 +266,7 @@ final class PerfOptions {
       $this->tcAlltrans = true;
     }
 
-    if ($isFacebook && $this->php5 === null && $this->hhvm === null) {
+    if ($isFacebook && $this->php === null && $this->hhvm === null) {
       $this->hhvm = $fbcode.'/_bin/hphp/hhvm/hhvm';
     }
 
@@ -306,7 +306,7 @@ final class PerfOptions {
   }
 
   public function validate() {
-    if ($this->php5) {
+    if ($this->php) {
       $this->precompile = false;
       $this->proxygen = false;
       $this->filecache = false;
@@ -324,13 +324,13 @@ final class PerfOptions {
         exit(1);
       }
     }
-    if ($this->php5 === null && $this->hhvm === null) {
+    if ($this->php === null && $this->hhvm === null) {
       invariant_violation(
-        'Either --php5=/path/to/php-cgi or --hhvm=/path/to/hhvm '.
+        'Either --php=/path/to/php-cgi or --hhvm=/path/to/hhvm '.
         "must be specified",
       );
     }
-    $engine = $this->php5 !== null ? $this->php5 : $this->hhvm;
+    $engine = $this->php !== null ? $this->php : $this->hhvm;
     invariant(
       shell_exec('which '.escapeshellarg($engine)) !== null ||
       is_executable($engine),

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -31,8 +31,8 @@ final class PerfRunner {
 
     $php_engine = null;
 
-    if ($options->php5) {
-      $php_engine = new PHP5Daemon($options);
+    if ($options->php) {
+      $php_engine = new PHPDaemon($options);
     }
     if ($options->hhvm) {
       $php_engine = new HHVMDaemon($options);


### PR DESCRIPTION
Summary:

In order to select php to run oss-performance you must pass --php5
options but, oss-performance runs with php7 as well. I guess makes more
sense to remove the suffix. This commit also changes PHP5Daemon to 
PHPDaemon for the same reason.