### PR TITLE
Fine tunning siege benchmark options

### DIFF
--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -108,6 +108,12 @@ final class PerfOptions {
   public ?string $scriptAfterWarmup;
   public ?string $scriptAfterBenchmark;
 
+
+  // Fine tune for some benchmark options.
+  public ?int $benchmarkConcurrency;
+  public ?string $benchmarkTime;
+  public ?int $benchmarkWarmConcurrency;
+
   public bool $notBenchmarking = false;
 
   private array $args;
@@ -142,6 +148,9 @@ final class PerfOptions {
       'profBC',
       'setUpTest:',
       'tearDownTest:',
+      'benchmark-time:',
+      'benchmark-concurrency:',
+      'benchmark-warm-concurrency:',
       'i-am-not-benchmarking',
       'hhvm-extra-arguments:',
       'php-extra-arguments:',
@@ -215,6 +224,11 @@ final class PerfOptions {
       $this->forceInnodb = true;
     }
 
+    $this->benchmarkTime = hphp_array_idx($o, 'benchmark-time', null);
+    $this->benchmarkConcurrency = hphp_array_idx($o, 'benchmark-concurrency',
+                                    null);
+    $this->benchmarkWarmConcurrency = hphp_array_idx($o,
+                                        'benchmark-warm-concurrency', null);
     $this->notBenchmarking = array_key_exists('i-am-not-benchmarking', $o);
 
     // If any arguments below here are given, then the "standard
@@ -374,6 +388,37 @@ final class PerfOptions {
         $this->hhvm !== null,
         'Only hhvm can be used with --repo-auth',
       );
+    }
+
+    if ($this->benchmarkTime != null) {
+      // [1-9]+[HMS]
+      if (!preg_match("/^[1-9][0-9]*[HMS]{1}$/", $this->benchmarkTime)) {
+        fprintf(STDERR, "*** WARNING ***\n Invalid benchmark time format: %s.
+          Examples of valid format are 2M, 30S, 1H. Using default 1M.\n",
+          $this->benchmarkTime);
+        // Already have a static method who return the default value for siege.
+        $this->benchmarkTime = null;
+      }
+    }
+
+    if ($this->benchmarkWarmConcurrency != null) {
+      if (!preg_match("/^[1-9][0-9]*/", $this->benchmarkWarmConcurrency)) {
+       fprintf(STDERR, "*** WARNING ***\n Invalid benchmark concurrency warmup
+         value: %s. Must be a value greater than 0. Using default 200.\n",
+         $this->benchmarkWarmConcurrency);
+       // Already have a static method who return the default value for siege.
+       $this->benchmarkWarmConcurrency = null;
+      }
+    }
+
+    if ($this->benchmarkConcurrency != null) {
+      if (!preg_match("/^[1-9][0-9]*/", $this->benchmarkConcurrency)) {
+       fprintf(STDERR, "*** WARNING ***\n Invalid benchmark concurrency value:
+         %s. Must be a value greater than 0. Using default 200.\n",
+         $this->benchmarkConcurrency);
+        // Already have a static method who return the default value for siege.
+        $this->benchmarkConcurrency = null;
+      }
     }
 
     SystemChecks::CheckAll($this);

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -114,10 +114,15 @@ final class Siege extends Process {
         );
         return $arguments;
       case RequestModes::WARMUP_MULTI:
+        if ($this->options->benchmarkWarmConcurrency != null) {
+          $concurrency = $this->options->benchmarkWarmConcurrency;
+        } else {
+          $concurrency = (string) PerfSettings::BenchmarkConcurrency();
+        }
         $arguments->addAll(
           Vector {
             '-c',
-            (string) PerfSettings::BenchmarkConcurrency(),
+            $concurrency,
             '-t',
             '1M',
             '-f',
@@ -128,10 +133,15 @@ final class Siege extends Process {
         );
         return $arguments;
       case RequestModes::BENCHMARK:
+        if ($this->options->benchmarkConcurrency != null) {
+          $concurrency = $this->options->benchmarkConcurrency;
+        } else {
+          $concurrency = (string) PerfSettings::BenchmarkConcurrency();
+        }
         $arguments->addAll(
           Vector {
             '-c',
-            (string) PerfSettings::BenchmarkConcurrency(),
+            $concurrency,
             '-f',
             $urls_file,
             '--benchmark',
@@ -141,7 +151,11 @@ final class Siege extends Process {
 
         if (!$this->options->noTimeLimit) {
           $arguments->add('-t');
-          $arguments->add(PerfSettings::BenchmarkTime());
+          if ($this->options->benchmarkTime == null) {
+            $arguments->add(PerfSettings::BenchmarkTime());
+          } else {
+            $arguments->add($this->options->benchmarkTime);
+          }
         }
         return $arguments;
       default:


### PR DESCRIPTION
Summary:

To set siege parameters for benchmark, oss-performance uses static
functions defined on PerfSettings.
It's seems more easy if we can do this via command line rather than
edit file.

This commit introduces three new command line options:

--benckmark-time
--benchmark-concurrency
--benchmark-warm-concurrency

Those functions permits to  set benchmark time, benchmark concurrency
and, warmup (multi) concurrency values. Oss-performance will use default
values if you don't pass anything or pass a invalid value.

Those options doen't affect single request warmup stage.