### PR TITLE
PHP-FPM integration

### DIFF
--- a/base/FPMDaemon.php
+++ b/base/FPMDaemon.php
@@ -1,0 +1,61 @@
+<?hh
+/*
+ *  Copyright (c) 2016, Intel Corporation.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+final class FPMDaemon extends PHPEngine {
+  private PerfTarget $target;
+
+  public function __construct(private PerfOptions $options) {
+    $this->target = $options->getTarget();
+    parent::__construct((string) $options->fpm);
+
+    // TOOD nice to have: check whether opcache is loaded
+  }
+
+  public function start(): void {
+    parent::startWorker(
+      $this->options->daemonOutputFileName('fpm'),
+      $this->options->delayProcessLaunch,
+      $this->options->traceSubProcess,
+    );
+  }
+
+  protected function getArguments(): Vector<string> {
+    $args = Vector {
+      '-y',
+      OSS_PERFORMANCE_ROOT.'/conf/php-fpm.conf',
+      '-c',
+      OSS_PERFORMANCE_ROOT.'/conf/php.ini',
+      '--pid',
+      $this->options->tempDir.'/php-fpm.pid',
+    };
+
+    if (count($this->options->phpExtraArguments) > 0) {
+      $args->addAll($this->options->phpExtraArguments);
+    }
+    return $args;
+  }
+
+  protected function getEnvironmentVariables(): Map<string, string> {
+    return Map {
+      'OSS_PERF_TARGET' => (string) $this->target,
+    };
+  }
+
+  public function __toString(): string {
+    return (string) $this->options->fpm;
+  }
+
+
+  <<__Override>>
+  protected function getPidFilePath(): string {
+    return $this->options->tempDir.'/php-fpm.pid';
+  }
+}

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -34,6 +34,9 @@ final class PerfRunner {
     if ($options->php5) {
       $php_engine = new PHP5Daemon($options);
     }
+    if ($options->fpm) {
+      $php_engine = new FPMDaemon($options);
+    }
     if ($options->hhvm) {
       $php_engine = new HHVMDaemon($options);
     }

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -1,0 +1,13 @@
+[global]
+error_log = /var/log/php-fpm/error.log
+daemonize = yes
+
+[www]
+listen = 127.0.0.1:8092
+listen.allowed_clients = 127.0.0.1
+
+pm = dynamic
+pm.max_children = 100
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 50


### PR DESCRIPTION
Added FPMDaemon class in order to benchmark php-fpm. The default fpm configuration and pool configuration is available in the conf/php-fpm.conf file.
Benchmarking php-fpm example:
hhvm perf.php --wordpress --fpm=/path/to/bin/php-fpm
