### PR TITLE
Disable asserts by default

### DIFF
--- a/conf/php.ini
+++ b/conf/php.ini
@@ -10,6 +10,7 @@ user_ini.filename=
 realpath_cache_size=2M
 cgi.check_shebang_line=0
 date.timezone=America/Los_Angeles
+assert.active=false
 
 ;;;;;;;;;;;;;
 ; HHVM Only ;


### PR DESCRIPTION
HHVM >= 3.12 enables asserts by default, which is what PHP does, but
previously it had them disabled by default. When oss-performance runs
against Mediawiki target it now fails for HHVM >= 3.12. At the client
side we get and "Internal server error": HTTP/1.1 500 hphp_invoke. At
the server side we get "Fatal error: assert() is not supported: assert
with strings argument in RepoAuthoritative mode in /<tmpdir>/mediawiki-
1.26.2/includes/parser/Preprocessor_Hash.php on line 485". Thus this
php.ini param. solves this issue by disabling asserts in repo-auth mode.