### PR TITLE
Benchmark time

### DIFF
--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -89,7 +89,7 @@ final class PerfOptions {
   public float $delayPhpStartup;
   public float $delayProcessLaunch; // secs to wait after start process
   public float $delayCheckHealth; // secs to wait before hit /check-health
-
+  public ?string $benchmarkTime; // mins to execute the benchmarking phase
   //
   // Maximum wait times, as for example given to file_get_contents
   // or the configuration file for nginx.  These times may be truncated
@@ -143,6 +143,7 @@ final class PerfOptions {
       'setUpTest:',
       'tearDownTest:',
       'i-am-not-benchmarking',
+      'benchmark-time:',
       'hhvm-extra-arguments:',
       'php-extra-arguments:',
       'php-fcgi-children:',
@@ -232,6 +233,7 @@ final class PerfOptions {
     $this->noTimeLimit = $this->getBool('no-time-limit');
     $this->waitAtEnd = $this->getBool('wait-at-end');
     $this->proxygen = !$this->getBool('no-proxygen');
+    $this->benchmarkTime = $this->getNullableString('benchmark-time');
     $this->applyPatches = $this->getBool('apply-patches');
 
     $this->precompile = !$this->getBool('no-repo-auth');

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -89,33 +89,38 @@ final class Siege extends Process {
         $tempArr = str_split($this->options->benchmarkTime);
         $i = 0;
         $time = $tempArr[$i];
-        $i++;
+	$i++;
 
 	while($i < ((count($tempArr)-1))){
- 	  $time = $time . $tempArr[$i];
+	  $time = $time . $tempArr[$i];
 	  $i++;
 	}
-
-	$time = intval($time);
-	$time = $time + 4;
-	   
+ 
 	switch(strtoupper($tempArr[$i])){
 	  case 'S':
+	    $time = intval($time);
+	    $time = $time + 240;
 	    $time = $time . 's';
 	    break;
 	  case 'M':
+	    $time = intval($time);
+	    $time = $time + 4;
 	    $time = $time . 'm';
             break;
           case 'H':
+            $time = floatval($time);
+            print('KEVIN2 ' . $time);
+            $time = $time + .066;
 	    $time = $time . 'h';
 	    break;
 	  default:
+            $time = intval($time);
+	    $time = $time + 4;
             $time = $time . 'm';
 	 }
       }else{
         $time = '5m';
       }
-	
       $arguments = Vector {
       // See Siege::getExecutablePath()  - these arguments get passed to
       // timeout

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -85,11 +85,41 @@ final class Siege extends Process {
 
     $arguments = Vector {};
     if (!$this->options->noTimeLimit) {
-      $arguments = Vector {
+	if($this->options->benchmarkTime !== null && strlen($this->options->benchmarkTime) >= 2){
+	   $tempArr = str_split($this->options->benchmarkTime);
+	   $i = 0;
+	   $time = $tempArr[$i];
+	   $i++;
+	   while($i < ((count($tempArr)-1))){
+ 	      $time = $time . $tempArr[$i];
+	      $i++;
+	   }
+	   $time = intval($time);
+	   $time = $time + 4;
+	   
+	   switch(strtoupper($tempArr[$i])){
+	      case 'S':
+	         $time = $time . 's';
+		 break;
+	      case 'M':
+		 $time = $time . 'm';
+		 break;
+	      case 'H':
+	         $time = $time . 'h';
+		 break;
+	      default:
+		$time = $time . 'm';
+	   }
+	print('two ' . $time);
+	}else{
+	   $time = '5m';
+	}
+	print("Three " . $time);
+	$arguments = Vector {
         // See Siege::getExecutablePath()  - these arguments get passed to
         // timeout
         '--signal=9',
-        '5m',
+        $time,
         parent::getExecutablePath(),
       };
     }

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -87,41 +87,41 @@ final class Siege extends Process {
     if (!$this->options->noTimeLimit) {
       if ($this->options->benchmarkTime !== null && strlen($this->options->benchmarkTime) >= 2){
         $tempArr = str_split($this->options->benchmarkTime);
-	  $i = 0;
-	  $time = $tempArr[$i];
+        $i = 0;
+        $time = $temparr[$i];
+        $i++;
+
+	while($i < ((count($tempArr)-1))){
+ 	  $time = $time . $tempArr[$i];
 	  $i++;
-
-	  while($i < ((count($tempArr)-1))){
- 	    $time = $time . $tempArr[$i];
-	    $i++;
-	  }
-
-	  $time = intval($time);
-	  $time = $time + 4;
-	   
-	  switch(strtoupper($tempArr[$i])){
-	    case 'S':
-	      $time = $time . 's';
-	      break;
-	    case 'M':
-	      $time = $time . 'm';
-              break;
-	    case 'H':
-	      $time = $time . 'h';
-	      break;
-	    default:
-              $time = $time . 'm';
-	   }
-	}else{
-	  $time = '5m';
 	}
+
+	$time = intval($time);
+	$time = $time + 4;
+	   
+	switch(strtoupper($tempArr[$i])){
+	  case 'S':
+	    $time = $time . 's';
+	    break;
+	  case 'M':
+	    $time = $time . 'm';
+            break;
+          case 'H':
+	    $time = $time . 'h';
+	    break;
+	  default:
+            $time = $time . 'm';
+	 }
+      }else{
+        $time = '5m';
+      }
 	
-	$arguments = Vector {
-        // See Siege::getExecutablePath()  - these arguments get passed to
-        // timeout
-        '--signal=9',
-        $time,
-        parent::getExecutablePath(),
+      $arguments = Vector {
+      // See Siege::getExecutablePath()  - these arguments get passed to
+      // timeout
+      '--signal=9',
+      $time,
+      parent::getExecutablePath(),
       };
     }
     $siege_rc = $this->target->getSiegeRCPath();

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -88,7 +88,7 @@ final class Siege extends Process {
       if ($this->options->benchmarkTime !== null && strlen($this->options->benchmarkTime) >= 2){
         $tempArr = str_split($this->options->benchmarkTime);
         $i = 0;
-        $time = $temparr[$i];
+        $time = $tempArr[$i];
         $i++;
 
 	while($i < ((count($tempArr)-1))){

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -141,7 +141,10 @@ final class Siege extends Process {
 
         if (!$this->options->noTimeLimit) {
           $arguments->add('-t');
-          $arguments->add(PerfSettings::BenchmarkTime());
+          if ($this->options->benchmarkTime === null)
+            $arguments->add(PerfSettings::BenchmarkTime());
+          else
+            $arguments->add((string)$this->options->benchmarkTime);
         }
         return $arguments;
       default:

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -109,7 +109,6 @@ final class Siege extends Process {
             break;
           case 'H':
             $time = floatval($time);
-            print('KEVIN2 ' . $time);
             $time = $time + .066;
 	    $time = $time . 'h';
 	    break;

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -85,36 +85,37 @@ final class Siege extends Process {
 
     $arguments = Vector {};
     if (!$this->options->noTimeLimit) {
-	if($this->options->benchmarkTime !== null && strlen($this->options->benchmarkTime) >= 2){
-	   $tempArr = str_split($this->options->benchmarkTime);
-	   $i = 0;
-	   $time = $tempArr[$i];
-	   $i++;
-	   while($i < ((count($tempArr)-1))){
- 	      $time = $time . $tempArr[$i];
-	      $i++;
-	   }
-	   $time = intval($time);
-	   $time = $time + 4;
+      if ($this->options->benchmarkTime !== null && strlen($this->options->benchmarkTime) >= 2){
+        $tempArr = str_split($this->options->benchmarkTime);
+	  $i = 0;
+	  $time = $tempArr[$i];
+	  $i++;
+
+	  while($i < ((count($tempArr)-1))){
+ 	    $time = $time . $tempArr[$i];
+	    $i++;
+	  }
+
+	  $time = intval($time);
+	  $time = $time + 4;
 	   
-	   switch(strtoupper($tempArr[$i])){
-	      case 'S':
-	         $time = $time . 's';
-		 break;
-	      case 'M':
-		 $time = $time . 'm';
-		 break;
-	      case 'H':
-	         $time = $time . 'h';
-		 break;
-	      default:
-		$time = $time . 'm';
+	  switch(strtoupper($tempArr[$i])){
+	    case 'S':
+	      $time = $time . 's';
+	      break;
+	    case 'M':
+	      $time = $time . 'm';
+              break;
+	    case 'H':
+	      $time = $time . 'h';
+	      break;
+	    default:
+              $time = $time . 'm';
 	   }
-	print('two ' . $time);
 	}else{
-	   $time = '5m';
+	  $time = '5m';
 	}
-	print("Three " . $time);
+	
 	$arguments = Vector {
         // See Siege::getExecutablePath()  - these arguments get passed to
         // timeout


### PR DESCRIPTION
Adding the command line parameter "--benchmark-time" which allows the user to specify the run-time of the selected benchmark. This is necessary when profiling with various tools that require a longer run time. Time passed in can be in seconds (S), minutes (M), or hours (H). 

We also add 4 minutes to whatever time the user passes in to account for the warm-up phases.

If the user passes in an incorrect value we default back to the standard 5M time.

example usage: 
--benchmark-time=120S 
--benchmark-time=7M
--benchmark-time=0.1H
