### PR TITLE
Fix use of invariant() calls when the string is not constant

### DIFF
--- a/base/BuildChecker.php
+++ b/base/BuildChecker.php
@@ -39,7 +39,9 @@ final class BuildChecker {
       if ($skipKeys->contains($k)) {
         continue;
       }
-      invariant(is_array($v), $k.' is not an array');
+      invariant(is_array($v), 
+		'%s', 
+		$k.' is not an array');
       $v = self::MakeCheckedValue($v);
       if ($v['OK']) {
         continue;

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -83,7 +83,7 @@ final class PerfRunner {
     $php_engine->start();
     Process::sleepSeconds($options->delayPhpStartup);
     invariant(
-      $php_engine->isRunning(),
+      $php_engine->isRunning(), '%s',
       'Failed to start '.get_class($php_engine),
     );
 
@@ -113,7 +113,7 @@ final class PerfRunner {
 
       invariant(!$siege->isRunning(), 'Siege is still running :/');
       invariant(
-        $php_engine->isRunning(),
+        $php_engine->isRunning(),'%s',
         get_class($php_engine).' crashed',
       );
     } else {
@@ -129,7 +129,7 @@ final class PerfRunner {
 
       invariant(!$siege->isRunning(), 'Siege is still running :/');
       invariant(
-        $php_engine->isRunning(),
+        $php_engine->isRunning(),'%s',
         get_class($php_engine).' crashed',
       );
     } else {

--- a/base/PerfTarget.php
+++ b/base/PerfTarget.php
@@ -29,7 +29,7 @@ abstract class PerfTarget {
       $this->getSanityCheckPath();
     $content = file_get_contents($url, /* include path = */ false, $ctx);
     invariant(
-      strstr($content, $this->getSanityCheckString()) !== false,
+      strstr($content, $this->getSanityCheckString()) !== false,'%s',
       'Failed to find string "'.$this->getSanityCheckString().'" in '.$url,
     );
   }

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -145,7 +145,7 @@ final class Siege extends Process {
         }
         return $arguments;
       default:
-        invariant_violation(
+        invariant_violation('%s',
           'Unexpected request mode: '.(string) $this->mode,
         );
     }

--- a/targets/wordpress/WordpressTarget.php
+++ b/targets/wordpress/WordpressTarget.php
@@ -99,7 +99,7 @@ final class WordpressTarget extends PerfTarget {
     );
     $data = file_get_contents($url, /* include path = */ false, $ctx);
     invariant(
-      $data !== false,
+      $data !== false,'%s',
       'Failed to unfreeze '.
       $url.
       ' after '.


### PR DESCRIPTION
Some of the invariant tests are using strings composed of a concatenation and not a simple string. Hack type check will barf on those. Fixed to set the format string to "%s" and the string a parameter to conform to hack type checking standard.