### PR TITLE
Update perf suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor/
 core
 core.*
 composer.phar
+perf.data
+processed-perf.data

--- a/base/DatabaseInstaller.php
+++ b/base/DatabaseInstaller.php
@@ -92,10 +92,16 @@ final class DatabaseInstaller {
   }
 
   private function getRootConnection(): resource {
-    print "MySQL admin user (default is 'root'): ";
-    $this->username = trim(fgets(STDIN)) ?: 'root';
-    fprintf(STDERR, '%s', 'MySQL admin password: ');
-    $this->password = trim(fgets(STDIN));
+    if ($this->options->dbUsername !== null
+        && $this->options->dbPassword !== null) {
+      $this->username = $this->options->dbUsername;
+      $this->password = $this->options->dbPassword;
+    } else {
+      print "MySQL admin user (default is 'root'): ";
+      $this->username = trim(fgets(STDIN)) ?: 'root';
+      fprintf(STDERR, '%s', 'MySQL admin password: ');
+      $this->password = trim(fgets(STDIN));
+    }
     $conn = mysql_connect('127.0.0.1', $this->username, $this->password);
     if ($conn === false) {
       throw new Exception('Failed to connect: '.mysql_error());

--- a/base/DatabaseInstaller.php
+++ b/base/DatabaseInstaller.php
@@ -15,7 +15,9 @@ final class DatabaseInstaller {
   private ?string $username;
   private ?string $password = null;
 
-  public function __construct(private PerfOptions $options): void {}
+  public function __construct(private PerfOptions $options): void {
+    $this->configureMysqlAffinity();
+  }
 
   public function getUsername(): ?string {
     return $this->username ? $this->username : $this->databaseName;
@@ -33,6 +35,14 @@ final class DatabaseInstaller {
   public function setDumpFile(string $dump_file): this {
     $this->dumpFile = $dump_file;
     return $this;
+  }
+
+  public function configureMysqlAffinity(): void {
+    if ($this->options->cpuBind) {
+      exec("sudo taskset -acp ".$this->options->helperProcessors." `pgrep mysqld`");
+      print "You need to restart mysql after the benchmarks to remove the ";
+      print "processor affinity.\n";
+    }
   }
 
   public function installDatabase(): bool {

--- a/base/HHVMDaemon.php
+++ b/base/HHVMDaemon.php
@@ -64,6 +64,9 @@ final class HHVMDaemon extends PHPEngine {
 
   <<__Override>>
   protected function getArguments(): Vector<string> {
+    if ($this->options->cpuBind) {
+      $this->cpuRange = $this->options->daemonProcessors;
+    }
     $args = Vector {
       '-m',
       'server',

--- a/base/HHVMDaemon.php
+++ b/base/HHVMDaemon.php
@@ -82,8 +82,6 @@ final class HHVMDaemon extends PHPEngine {
       'Server.ErrorDocument404=index.php',
       '-v',
       'Server.SourceRoot='.$this->target->getSourceRoot(),
-      '-v',
-      'Eval.Jit=1',
       '-d',
       'hhvm.log.file='.$this->options->tempDir.'/hhvm_error.log',
       '-d',
@@ -91,6 +89,14 @@ final class HHVMDaemon extends PHPEngine {
       '-c',
       OSS_PERFORMANCE_ROOT.'/conf/php.ini',
     };
+    if ($this->options->jit) {
+      $args->addAll(Vector {'-v', 'Eval.Jit=1'});
+    } else {
+      $args->addAll(Vector {'-v', 'Eval.Jit=0'});
+    }
+    if ($this->options->statCache) {
+      $args->addAll(Vector {'-v', 'Server.StatCache=1'});
+    }
     if ($this->options->pcreCache) {
       $args->addAll(
         Vector {'-v', 'Eval.PCRECacheType='.$this->options->pcreCache},

--- a/base/NginxDaemon.php
+++ b/base/NginxDaemon.php
@@ -110,6 +110,9 @@ final class NginxDaemon extends Process {
 
   <<__Override>>
   protected function getArguments(): Vector<string> {
+    if ($this->options->cpuBind) {
+      $this->cpuRange = $this->options->helperProcessors;
+    }
     return Vector {
       '-c',
       $this->getGeneratedConfigFile(),

--- a/base/PHP5Daemon.php
+++ b/base/PHP5Daemon.php
@@ -16,30 +16,51 @@ final class PHP5Daemon extends PHPEngine {
     $this->target = $options->getTarget();
     parent::__construct((string) $options->php5);
 
-    $output = [];
-    $check_command = implode(
-      ' ',
-      (Vector {
-         $options->php5,
-         '-q',
-         '-c',
-         OSS_PERFORMANCE_ROOT.'/conf',
-         __DIR__.'/php-src_config_check.php',
-       })->map($x ==> escapeshellarg($x)),
-    );
+    if ($options->fpm) {
+      $output = [];
+      $check_command = implode(
+        ' ',
+        (Vector {
+           $options->php5,
+           '-i',
+           '-c',
+           OSS_PERFORMANCE_ROOT.'/conf',
+         })->map($x ==> escapeshellarg($x)),
+      );
 
-    if ($options->traceSubProcess) {
-      fprintf(STDERR, "%s\n", $check_command);
+      // Basic check for opcode caching.
+      if ($options->traceSubProcess) {
+        fprintf(STDERR, "%s\n", $check_command);
+      }
+      exec($check_command, $output);
+      $check = array_search('Opcode Caching => Up and Running', $output, true);
+      invariant($check, 'Got invalid output from php-fpm -i');
+    } else {
+      $output = [];
+      $check_command = implode(
+        ' ',
+        (Vector {
+           $options->php5,
+           '-q',
+           '-c',
+           OSS_PERFORMANCE_ROOT.'/conf',
+           __dir__.'/php-src_config_check.php',
+         })->map($x ==> escapeshellarg($x)),
+      );
+
+      if ($options->traceSubProcess) {
+        fprintf(STDERR, "%s\n", $check_command);
+      }
+      exec($check_command, $output);
+      $checks = json_decode(implode("\n", $output), /* as array = */ true);
+      invariant($checks, 'Got invalid output from php-src_config_check.php');
+      BuildChecker::Check(
+        $options,
+        (string) $options->php5,
+        $checks,
+        Set {'PHP_VERSION', 'PHP_VERSION_ID'},
+      );
     }
-    exec($check_command, $output);
-    $checks = json_decode(implode("\n", $output), /* as array = */ true);
-    invariant($checks, 'Got invalid output from php-src_config_check.php');
-    BuildChecker::Check(
-      $options,
-      (string) $options->php5,
-      $checks,
-      Set {'PHP_VERSION', 'PHP_VERSION_ID'},
-    );
   }
 
   public function start(): void {
@@ -51,12 +72,37 @@ final class PHP5Daemon extends PHPEngine {
   }
 
   protected function getArguments(): Vector<string> {
-    $args = Vector {
-      '-b',
-      '127.0.0.1:'.PerfSettings::BackendPort(),
-      '-c',
-      OSS_PERFORMANCE_ROOT.'/conf/',
-    };
+    if ($this->options->fpm) {
+      echo 'Creating PHP FPM config';
+      $path = $this->options->tempDir.'/php-fpm.conf';
+      $config = file_get_contents(OSS_PERFORMANCE_ROOT.'/conf/php-fpm.conf.in');
+      $config = str_replace(
+        "__FASTCGI_PORT__",
+        PerfSettings::BackendPort(),
+        $config
+      );
+      $config = str_replace(
+        "__TMP_DIR__",
+        $this->options->tempDir,
+        $config
+      );
+      file_put_contents($path, $config);
+
+      $args = Vector {
+        '-F',
+        '--fpm-config',
+        $path,
+        '-c',
+        OSS_PERFORMANCE_ROOT.'/conf/',
+      };
+    } else {
+      $args = Vector {
+        '-b',
+        '127.0.0.1:'.PerfSettings::BackendPort(),
+        '-c',
+        OSS_PERFORMANCE_ROOT.'/conf/',
+      };
+    }
 
     if (count($this->options->phpExtraArguments) > 0) {
       $args->addAll($this->options->phpExtraArguments);
@@ -102,7 +148,8 @@ final class PHP5Daemon extends PHPEngine {
     if (!file_exists($exe)) {
       return false;
     }
-    return (bool) preg_match('/php.*-cgi/', readlink($exe));
+    return (bool) preg_match('/php.*-cgi/', readlink($exe)) ||
+           (bool) preg_match('/php.*-fpm/', readlink($exe));
   }
 
   protected function getEnvironmentVariables(): Map<string, string> {

--- a/base/PHP5Daemon.php
+++ b/base/PHP5Daemon.php
@@ -72,6 +72,9 @@ final class PHP5Daemon extends PHPEngine {
   }
 
   protected function getArguments(): Vector<string> {
+    if ($this->options->cpuBind) {
+      $this->cpuRange = $this->options->daemonProcessors;
+    }
     if ($this->options->fpm) {
       echo 'Creating PHP FPM config';
       $path = $this->options->tempDir.'/php-fpm.conf';

--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -274,7 +274,7 @@ final class PerfOptions {
     $this->forceInnodb = $isFacebook || $this->getBool('force-innodb');
 
     if ($isFacebook && $this->php5 === null && $this->hhvm === null) {
-      $this->hhvm = $fbcode.'/_bin/hphp/hhvm/hhvm';
+      $this->hhvm = $fbcode.'/buck-out/gen/hphp/hhvm/hhvm/hhvm';
     }
 
     $this->traceSubProcess = $this->getBool('trace');

--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -74,6 +74,8 @@ final class PerfOptions {
   public bool $allVolatile = false;
   public bool $interpPseudomains = false;
   public bool $proxygen = false;
+  public bool $jit = false;
+  public bool $statCache = false;
 
   //
   // HHVM specific options for generating performance data and profiling
@@ -135,7 +137,9 @@ final class PerfOptions {
       'wait-after-warmup',
       'no-proxygen',
       'no-repo-auth',
+      'no-jit',
       'no-file-cache',
+      'stat-cache',
       'pcre-cache:',
       'pcre-cache-expire:',
       'pcre-cache-size:',
@@ -258,6 +262,8 @@ final class PerfOptions {
     $this->noTimeLimit = $this->getBool('no-time-limit');
     $this->waitAtEnd = $this->getBool('wait-at-end');
     $this->proxygen = !$this->getBool('no-proxygen');
+    $this->statCache = $this->getBool('stat-cache');
+    $this->jit = !$this->getBool('no-jit');
     $this->applyPatches = $this->getBool('apply-patches');
 
     $fraction = $this->getFloat('cpu-fraction', 1.0);
@@ -332,6 +338,7 @@ final class PerfOptions {
     if ($this->php5) {
       $this->precompile = false;
       $this->proxygen = false;
+      $this->jit = false;
       $this->filecache = false;
     }
     if ($this->hhvm) {

--- a/base/Process.php
+++ b/base/Process.php
@@ -14,6 +14,7 @@ abstract class Process {
   protected ?resource $stdin;
   protected ?resource $stdout;
   protected ?string $command;
+  protected ?string $cpuRange = null;
   protected bool $suppress_stdout = false;
 
   private static Vector<Process> $processes = Vector {};
@@ -54,6 +55,11 @@ abstract class Process {
     if ($this->suppress_stdout) {
       $this->command .= ' >/dev/null';
     }
+
+    if ($this->cpuRange !== null) {
+      $this->command = 'taskset -c '.$this->cpuRange.' '.$this->command;
+    }
+
     $use_pipe = ($outputFileName === null);
     $spec =
       [

--- a/base/Siege.php
+++ b/base/Siege.php
@@ -84,6 +84,9 @@ final class Siege extends Process {
 
   <<__Override>>
   protected function getArguments(): Vector<string> {
+    if ($this->options->cpuBind) {
+      $this->cpuRange = $this->options->helperProcessors;
+    }
     $urls_file = tempnam($this->options->tempDir, 'urls');
     $urls = file_get_contents($this->target->getURLsFile());
     $urls =

--- a/batch-run.json.example
+++ b/batch-run.json.example
@@ -44,6 +44,10 @@
   },
   "settings": {
     "username": "root",
-    "password": "root"
+    "password": "root",
+    "options": [
+      "cpu-fraction=0.5",
+      "i-am-not-benchmarking"
+    ]
   }
 }

--- a/batch-run.json.example
+++ b/batch-run.json.example
@@ -1,51 +1,49 @@
 {
   "runtimes": {
-    "HHVM 3.1 (2014-05-27)": {
+    "HHVM 3.18": {
       "type": "hhvm",
-      "bin": "hhvm-3.1.0"
+      "bin": "hhvm"
     },
-    "HHVM 3.4 (2014-11-14)": {
+    "HHVM 3.18 (norepo auth)": {
       "type": "hhvm",
-      "bin": "hhvm-3.4.0"
+      "bin": "hhvm",
+      "args": [
+        "--no-repo-auth",
+        "--i-am-not-benchmarking"
+      ]
     },
-    "HHVM 3.5 (2015-01-16)": {
-      "type": "hhvm",
-      "bin": "hhvm-3.5.0"
+    "PHP7 FPM": {
+      "type": "php-fpm",
+      "bin": "php-fpm7.0"
     },
-    "PHP7 (*)": {
+    "PHP7 CGI": {
       "type": "php-src",
-      "bin": "php7-cgi-2015-01-14"
-    },
-    "PHP 5.6.5 (2015-01-22)": {
-      "type": "php-src",
-      "bin": "php-cgi-5.6.5"
+      "bin": "php-cgi7.0"
     }
   },
   "targets": [
     "wordpress",
     "drupal7",
+    "drupal8-no-cache",
     "mediawiki",
-    "magento1",
-    "sugarcrm-login-page",
-    "sugarcrm-home-page"
+    "magento1"
   ],
   "runtime-overrides": {
-    "sugarcrm-home-page": {
-      "__comment": [
-        "Recent versions of PHP7 segfault in clean_non_persistent_constants()"
-      ],
-      "PHP7 (*)": {
-        "bin": "php7-cgi-2014-08-15"
-      }
-    },
     "magento1": {
       "__comment": [
         "Recent versions of PHP7 can not run Magento1 because of",
         "https://wiki.php.net/rfc/uniform_variable_syntax"
       ],
-      "PHP7 (*)": {
-        "bin": "php7-cgi-2014-08-15"
+      "PHP7 FPM": {
+        "skip": true
+      },
+      "PHP7 CGI": {
+        "skip": true
       }
     }
+  },
+  "settings": {
+    "username": "root",
+    "password": "root"
   }
 }

--- a/batch-run.php
+++ b/batch-run.php
@@ -143,6 +143,13 @@ function batch_get_single_run(
   $argv->addAll($runtime['args']);
   $argv[] = '--'.$target['name'];
 
+  foreach ($target['settings'] as $name => $value) {
+    if ($name === 'options') {
+      foreach ((array)$value as $v) {
+        $argv[] = '--'.$v;
+      }
+    }
+  }
   $options = new PerfOptions($argv);
   switch ($runtime['type']) {
     case BatchRuntimeType::HHVM:

--- a/conf/php-fpm.conf.in
+++ b/conf/php-fpm.conf.in
@@ -1,0 +1,27 @@
+;;;;;;;;;;;;;;;;;;;;;
+; FPM Configuration ;
+;;;;;;;;;;;;;;;;;;;;;
+
+[global]
+; Pid file
+pid = /__TMP_DIR__/php7.0-fpm.pid
+
+; Error log file
+error_log = /__TMP_DIR__/php7.0-fpm.log
+
+;;;;;;;;;;;;;;;;;;;;
+; Pool Definitions ;
+;;;;;;;;;;;;;;;;;;;;
+
+[www]
+; The address on which to accept FastCGI requests.
+listen = 127.0.0.1:__FASTCGI_PORT__
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+listen.allowed_clients = 127.0.0.1
+
+;   static  - a fixed number (pm.max_children) of child processes;
+pm = static
+
+; The number of child processes to be created when pm is set to 'static'
+pm.max_children = 100

--- a/scripts/perf.sh
+++ b/scripts/perf.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -xe
+
+# Switch to scripts dir.
+cd "$(dirname "$0")"
+ARGS="$@"
+
+echo "Running as $(whoami)"
+
+HHVM_PID="$(pgrep -xn 'hhvm')"
+OSS_DIR=$(pwd)
+
+echo "The first arg is the output directory."
+echo "The remaining args are passed along to perf record."
+echo "Running perf on HHVM pid: $HHVM_PID"
+
+
+# Go to repo root.
+cd "$OSS_DIR/.."
+sudo nohup sh -xec "timeout --signal INT 30s \
+  perf record -a -g -D 5000 $ARGS -p $HHVM_PID" >nohup.out &

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-sudo apt-get -y install nginx unzip mysql-server
+sudo apt-get -y install nginx unzip mysql-server util-linux coreutils
 sudo apt-get -y install autotools-dev
 sudo apt-get -y install autoconf
 sudo apt-get -y install software-properties-common build-essential

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+sudo apt-get -y install nginx unzip mysql-server
+sudo apt-get -y install autotools-dev
+sudo apt-get -y install autoconf
+sudo apt-get -y install software-properties-common build-essential
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449
+sudo add-apt-repository "deb http://dl.hhvm.com/ubuntu xenial main"
+sudo apt-get update
+sudo apt-get -y install hhvm
+sudo apt-get -y install php7.0 php7.0-cgi php7.0-fpm
+sudo apt-get -y install php7.0-mysql php7.0-curl php7.0-gd php7.0-intl php-pear php-imagick php7.0-imap php7.0-mcrypt php-memcache  php7.0-pspell php7.0-recode php7.0-sqlite3 php7.0-tidy php7.0-xmlrpc php7.0-xsl php7.0-mbstring php-gettext
+
+git clone https://github.com/JoeDog/siege.git
+cd siege
+git checkout tags/v4.0.3rc3
+./utils/bootstrap
+automake --add-missing
+./configure
+make
+sudo make uninstall
+sudo make install
+cd ..
+rm -rf siege
+
+cd "$(dirname "$0")"
+cd ..
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '55d6ead61b29c7bdee5cccfb50076874187bd9f21f65d8991d46ec5cc90518f447387fb9f76ebae1fbbacf329e583e30') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+
+php composer.phar install
+
+for file in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+  sudo -- sh -c "echo performance > $file"
+done
+
+echo 1 | sudo tee /proc/sys/net/ipv4/tcp_tw_reuse
+
+echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo || true

--- a/targets/mediawiki/LocalSettings.php
+++ b/targets/mediawiki/LocalSettings.php
@@ -55,7 +55,7 @@ $wgEmailAuthentication = true;
 
 ## Database settings
 $wgDBtype = "mysql";
-#$wgDBserver = "localhost";
+$wgDBserver = "127.0.0.1";
 $wgDBname = "mw_bench";
 $wgDBuser = "mw_bench";
 $wgDBpassword = "mw_bench";

--- a/targets/mediawiki/MediaWikiTarget.php
+++ b/targets/mediawiki/MediaWikiTarget.php
@@ -11,7 +11,7 @@
 
 final class MediaWikiTarget extends PerfTarget {
 
-  const MEDIAWIKI_VERSION = 'mediawiki-1.26.2';
+  const MEDIAWIKI_VERSION = 'mediawiki-1.28.0';
 
   public function __construct(private PerfOptions $options) {}
 


### PR DESCRIPTION
This incorporates the following major changes:
  - Adds support for php-fpm
  - Updates mediawiki target to 1.28
  - Updates the tcprint and instructions for its use.
  - Updates siege flags to allow siege 4.03+ to work
  - Adds a setup script for Ubuntu