### PR TITLE
Adding a command line option to specify a remote Siege client.

### DIFF
--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -180,6 +180,11 @@ final class PerfRunner {
     }
 
     self::PrintProgress('Collecting results');
+    if ($options->remoteSiege) {
+      exec((' scp ' .
+        $options->remoteSiege . ':' . $options->siegeTmpDir . '/* '.
+        $options->tempDir));
+    }
 
     $combined_stats = Map {};
     $siege_stats = $siege->collectStats();

--- a/base/SiegeStats.php
+++ b/base/SiegeStats.php
@@ -15,6 +15,10 @@ trait SiegeStats {
   public function collectStats(): Map<string, Map<string, num>> {
     $log_lines =
       explode("\n", trim(file_get_contents($this->getLogFilePath())));
+    if (count($log_lines) > 1) {
+      // Remove possible header line
+      array_splice($log_lines, 0, 1);
+    }
     invariant(
       count($log_lines) === 1,
       'Expected 1 line in siege log file, got %d',


### PR DESCRIPTION
Please note you must set up privileged SSH connection between the Server and Client.
It is also necessary to modify IP tables to allow INPUT and OUTPUT between Server and Client.
Remote Client is specified by --remote-siege=user@host, and is to be paried with --i-am-not-benchmarking.