### PR TITLE
add wait for message queue to drain before final siege

### DIFF
--- a/base/HHVMDaemon.php
+++ b/base/HHVMDaemon.php
@@ -69,6 +69,15 @@ final class HHVMDaemon extends PHPEngine {
   }
 
   <<__Override>>
+  public function queueEmpty(): bool {
+    $status = $this->adminRequest('/check-queued');
+    if ($status === 'failure') {
+      return true;
+    }
+    return $status !== '' && $status === '0';
+  }
+
+  <<__Override>>
   protected function getArguments(): Vector<string> {
     if ($this->options->cpuBind) {
       $this->cpuRange = $this->options->daemonProcessors;

--- a/base/PHPEngine.php
+++ b/base/PHPEngine.php
@@ -14,4 +14,5 @@ abstract class PHPEngine extends Process {
   public function writeStats(): void {}
 
   public function needsRetranslatePause(): bool { return false; }
+  public function queueEmpty(): bool { return true; }
 }

--- a/base/PerfRunner.php
+++ b/base/PerfRunner.php
@@ -155,6 +155,12 @@ final class PerfRunner {
       );
     }
 
+    self::PrintProgress('Server warmed, checking queue status.');
+    while (!$options->skipWarmUp && !$php_engine->queueEmpty()) {
+      self::PrintProgress('Server warmed, waiting for queue to drain.');
+      sleep(10);
+    }
+
     self::PrintProgress('Clearing nginx access.log');
     $nginx->clearAccessLog();
 


### PR DESCRIPTION

For older Aarch64 hosts the /warmup-status message is not sufficient to determine
that the server is warmed up and ready to collect benchmarking numbers.  The longer
running benchmarks may still have a number of messages still waiting in the queue.

This change adds another wait loop before the final siege to make sure the queue is
empty and new requests will go through the JIT after the retranslateAll.

(Yes, this showed up with toys-fibonacci if you were curious)
