### PR TITLE
Adds robustness to the perf.sh method for finding hhvm pid.

### DIFF
--- a/scripts/perf.sh
+++ b/scripts/perf.sh
@@ -9,6 +9,10 @@ ARGS="$@"
 echo "Running as $(whoami)"
 
 HHVM_PID="$(pgrep -xn 'hhvm')"
+PREV_PID=`expr $HHVM_PID - 1`
+if [ ! -f /tmp/perf-$HHVM_PID.map ] && [ -f /tmp/perf-$PREV_PID.map ]; then
+    HHVM_PID=$PREV_PID
+fi
 OSS_DIR=$(pwd)
 
 echo "The first arg is the output directory."


### PR DESCRIPTION
Sometimes, the newest pid returned from pgrep -xn hhvm is a child
process of the parent hhvm process. In this case the perf-<pid>.map
file is missing, so just subract one and use the parent process.
Note: This process is not the instance of hhvm running perf.php.